### PR TITLE
Add an adaptive client that can auto detect the server type

### DIFF
--- a/rtsp_to_webrtc/client.py
+++ b/rtsp_to_webrtc/client.py
@@ -1,5 +1,57 @@
 """Client library for RTSPtoWebRTC server."""
 
-from . import webrtc_client
+from __future__ import annotations
 
-Client = webrtc_client.WebRTCClient
+import logging
+
+import aiohttp
+
+from .exceptions import ClientError
+from .interface import WebRTCClientInterface
+from .web_client import WebClient
+from .webrtc_client import WebRTCClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# For backwards compatibility. Deprecated and will be removed in the future.
+Client = WebRTCClient
+
+
+async def get_adaptive_client(
+    websession: aiohttp.ClientSession, server_url: str | None = None
+) -> WebRTCClientInterface:
+    """Initialize Client that can auto-detect the appropriate client for the server."""
+    web_client = WebClient(websession, server_url)
+    webrtc_client = WebRTCClient(websession, server_url)
+
+    web_heartbeat = web_client.heartbeat()
+    webrtc_heartbeat = webrtc_client.heartbeat()
+
+    client: WebRTCClientInterface | None = None
+    web_err: ClientError | None = None
+    try:
+        await web_heartbeat
+    except ClientError as err:
+        _LOGGER.debug("Discovery of RTSPtoWeb server failed: %s", str(err))
+        web_err = err
+    else:
+        client = web_client
+    webrtc_err: ClientError | None = None
+    try:
+        await webrtc_heartbeat
+    except ClientError as err:
+        _LOGGER.debug("Discovery of RTSPtoWebRTC server failed: %s", str(err))
+        webrtc_err = err
+    else:
+        if not client:
+            client = webrtc_client
+
+    if client:
+        return client
+
+    raise ClientError(
+        "Discovery of RTSPtoWeb or RTSPtoWebRTC servers failed (%s, %s)",
+        str(web_err),
+        str(webrtc_err),
+    )

--- a/rtsp_to_webrtc/interface.py
+++ b/rtsp_to_webrtc/interface.py
@@ -1,0 +1,11 @@
+"""Interface for client library for RTSPtoWeb / RTSPtoWebRTC server."""
+
+from abc import ABC, abstractmethod
+
+
+class WebRTCClientInterface(ABC):
+    """Client for RTSPtoWeb / RTSPtoWebRTC server."""
+
+    @abstractmethod
+    async def offer(self, offer_sdp: str, rtsp_url: str) -> str:
+        """Send the WebRTC offer to the server."""

--- a/rtsp_to_webrtc/web_client.py
+++ b/rtsp_to_webrtc/web_client.py
@@ -154,9 +154,6 @@ class WebClient:
         answer = base64.b64decode(text).decode("utf-8")
         return answer
 
-    async def offer(self, offer_sdp: str, rtsp_url: str) -> str:
-        """Send the WebRTC offer to the RTSPtoWeb server."""
-
     async def heartbeat(self) -> None:
         """Send a request to the server to determine if it is alive."""
         # ignore result

--- a/rtsp_to_webrtc/web_client.py
+++ b/rtsp_to_webrtc/web_client.py
@@ -11,6 +11,7 @@ from urllib.parse import urljoin
 import aiohttp
 
 from .exceptions import ClientError, ResponseError
+from .interface import WebRTCClientInterface
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class StatusCode(enum.Enum):
     SUCCESS = "1"
 
 
-class WebClient:
+class WebClient(WebRTCClientInterface):
     """Client for RTSPtoWeb server."""
 
     def __init__(
@@ -154,6 +155,11 @@ class WebClient:
         answer = base64.b64decode(text).decode("utf-8")
         return answer
 
+    async def offer(self, offer_sdp: str, rtsp_url: str) -> str:
+        """Send the WebRTC offer to the RTSPtoWeb server."""
+        # Place holder offer API
+        return await self.webrtc("ignored", "0", offer_sdp)
+
     async def heartbeat(self) -> None:
         """Send a request to the server to determine if it is alive."""
         # ignore result
@@ -181,7 +187,10 @@ class WebClient:
 
     async def _get_payload(self, resp: aiohttp.ClientResponse) -> Any:
         """Return payload from the response."""
-        result = await resp.json()
+        try:
+            result = await resp.json()
+        except aiohttp.ClientResponseError as err:
+            raise ResponseError("RTSPtoWeb server response decode error: ", str(err))
         if DATA_STATUS not in result:
             raise ResponseError(f"RTSPtoWeb server missing status: {result}")
         if str(result[DATA_STATUS]) != StatusCode.SUCCESS.value:

--- a/rtsp_to_webrtc/webrtc_client.py
+++ b/rtsp_to_webrtc/webrtc_client.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin
 import aiohttp
 
 from .exceptions import ClientError, ResponseError
+from .interface import WebRTCClientInterface
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ DATA_SDP64 = "sdp64"
 DATA_ERROR = "error"
 
 
-class WebRTCClient:
+class WebRTCClient(WebRTCClientInterface):
     """Client for RTSPtoWebRTC server."""
 
     def __init__(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+import aiohttp
+import pytest
+from aiohttp import ClientSession, web
+from aiohttp.test_utils import TestClient, TestServer
+
+from rtsp_to_webrtc.client import get_adaptive_client
+from rtsp_to_webrtc.exceptions import ClientError
+
+OFFER_SDP = "v=0\r\no=carol 28908764872 28908764872 IN IP4 100.3.6.6\r\n..."
+ANSWER_SDP = "v=0\r\no=bob 2890844730 2890844730 IN IP4 h.example.com\r\n..."
+ANSWER_PAYLOAD = base64.b64encode(ANSWER_SDP.encode("utf-8")).decode("utf-8")
+RTSP_URL = "rtsp://example"
+STREAM_1 = {
+    "name": "test video",
+    "channels": {
+        "0": {
+            "name": "ch1",
+            "url": "rtsp://example",
+        },
+        "1": {
+            "name": "ch2",
+            "url": "rtsp://example",
+        },
+    },
+}
+
+
+@pytest.fixture
+def event_loop() -> Any:
+    loop = asyncio.get_event_loop()
+    yield loop
+
+
+@pytest.fixture
+def cli_cb(
+    loop: Any,
+    app: web.Application,
+    aiohttp_client: Callable[[web.Application], Awaitable[TestClient]],
+) -> Callable[[], Awaitable[TestClient]]:
+    """Creates a fake aiohttp client."""
+
+    async def func() -> TestClient:
+        return await aiohttp_client(app)
+
+    return func
+
+
+async def test_adaptive_web_client(
+    cli_cb: Callable[[], Awaitable[TestClient]],
+    app: web.Application,
+    request_handler: Callable[[aiohttp.web.Request], Awaitable[aiohttp.web.Response]],
+) -> None:
+    """Test adapative client picks Web when both succeed."""
+    app.router.add_get("/streams", request_handler)
+    app.router.add_get("/static", request_handler)
+    app.router.add_post(
+        "/stream/{stream_id}/channel/{channel_id}/webrtc", request_handler
+    )
+    cli = await cli_cb()
+    assert isinstance(cli.server, TestServer)
+    # Web heartbeat
+    cli.server.app["response"].append(
+        aiohttp.web.json_response(
+            {
+                "status": 1,
+                "payload": {
+                    "demo1": STREAM_1,
+                },
+            }
+        )
+    )
+    # WebRTC heartbeat
+    cli.server.app["response"].append(
+        aiohttp.web.Response(status=404),
+    )
+    # Web Offer
+    cli.server.app["response"].append(aiohttp.web.Response(body=ANSWER_PAYLOAD))
+
+    client = await get_adaptive_client(cast(ClientSession, cli))
+
+    answer_sdp = await client.offer(OFFER_SDP, RTSP_URL)
+    assert answer_sdp == ANSWER_SDP
+
+
+async def test_adaptive_both_succeed_web_client(
+    cli_cb: Callable[[], Awaitable[TestClient]],
+    app: web.Application,
+    request_handler: Callable[[aiohttp.web.Request], Awaitable[aiohttp.web.Response]],
+) -> None:
+    """Test adapative client picks Web when both succeed."""
+    app.router.add_get("/streams", request_handler)
+    app.router.add_get("/static", request_handler)
+    app.router.add_post(
+        "/stream/{stream_id}/channel/{channel_id}/webrtc", request_handler
+    )
+    cli = await cli_cb()
+    assert isinstance(cli.server, TestServer)
+    # Web heartbeat
+    cli.server.app["response"].append(
+        aiohttp.web.json_response(
+            {
+                "status": 1,
+                "payload": {
+                    "demo1": STREAM_1,
+                },
+            }
+        )
+    )
+    # WebRTC heartbeat
+    cli.server.app["response"].append(
+        aiohttp.web.Response(status=200),
+    )
+    # Web Offer
+    cli.server.app["response"].append(aiohttp.web.Response(body=ANSWER_PAYLOAD))
+
+    client = await get_adaptive_client(cast(ClientSession, cli))
+
+    answer_sdp = await client.offer(OFFER_SDP, RTSP_URL)
+    assert answer_sdp == ANSWER_SDP
+
+
+async def test_adaptive_webrtc_client(
+    cli_cb: Callable[[], Awaitable[TestClient]],
+    app: web.Application,
+    request_handler: Callable[[aiohttp.web.Request], Awaitable[aiohttp.web.Response]],
+) -> None:
+    """Test List Streams calls."""
+    app.router.add_get("/streams", request_handler)
+    app.router.add_get("/static", request_handler)
+    app.router.add_post("/stream", request_handler)
+    cli = await cli_cb()
+    assert isinstance(cli.server, TestServer)
+    # Web heartbeat fails
+    cli.server.app["response"].append(aiohttp.web.Response(status=404))
+    # WebRTC heartbeat succeeds
+    cli.server.app["response"].append(
+        aiohttp.web.Response(status=200),
+    )
+    # WebRTC offer
+    cli.server.app["response"].append(
+        aiohttp.web.json_response({"sdp64": ANSWER_PAYLOAD})
+    )
+
+    client = await get_adaptive_client(cast(ClientSession, cli))
+
+    answer_sdp = await client.offer(OFFER_SDP, RTSP_URL)
+    assert answer_sdp == ANSWER_SDP
+
+
+async def test_adaptive_both_fail(
+    cli_cb: Callable[[], Awaitable[TestClient]],
+    app: web.Application,
+) -> None:
+    """Test successful response from RTSPtoWebRTC server."""
+    cli = await cli_cb()
+    assert isinstance(cli.server, TestServer)
+
+    with pytest.raises(ClientError):
+        await get_adaptive_client(cast(ClientSession, cli))


### PR DESCRIPTION
Add a client library factory method that is a thing shim across the two client libraries. It can present itself as a client that auto detects the server type, either RTSPtoWebRTC or RTSPtoWeb since both provide the same functionality.