### PR TITLE
Add support for passing extra data in the stream channel

### DIFF
--- a/rtsp_to_webrtc/interface.py
+++ b/rtsp_to_webrtc/interface.py
@@ -1,6 +1,9 @@
 """Interface for client library for RTSPtoWeb / RTSPtoWebRTC server."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class WebRTCClientInterface(ABC):
@@ -12,7 +15,11 @@ class WebRTCClientInterface(ABC):
 
     @abstractmethod
     async def offer_stream_id(
-        self, stream_id: str, offer_sdp: str, rtsp_url: str
+        self,
+        stream_id: str,
+        offer_sdp: str,
+        rtsp_url: str,
+        channel_data: dict[str, Any] | None = None,
     ) -> str:
         """Send the WebRTC offer to the server."""
 

--- a/rtsp_to_webrtc/web_client.py
+++ b/rtsp_to_webrtc/web_client.py
@@ -185,18 +185,25 @@ class WebClient(WebRTCClientInterface):
         return await self.offer_stream_id(stream_id, offer_sdp, rtsp_url)
 
     async def offer_stream_id(
-        self, stream_id: str, offer_sdp: str, rtsp_url: str
+        self,
+        stream_id: str,
+        offer_sdp: str,
+        rtsp_url: str,
+        channel_data: dict[str, Any] | None = None,
     ) -> str:
         """Send the WebRTC offer to the RTSPtoWeb server."""
         # Generate a fake stream id to use until API is updated to pass a
         # client generated id
         streams = await self.list_streams()
+        if channel_data is None:
+            channel_data = {}
         stream_payload = {
             "name": stream_id,
             "channels": {
                 "0": {
                     "name": "ch1",
                     "url": rtsp_url,
+                    **channel_data,
                 },
             },
         }

--- a/rtsp_to_webrtc/webrtc_client.py
+++ b/rtsp_to_webrtc/webrtc_client.py
@@ -39,17 +39,24 @@ class WebRTCClient(WebRTCClientInterface):
         return await self.offer_stream_id("ignored", offer_sdp, rtsp_url)
 
     async def offer_stream_id(
-        self, stream_id: str, offer_sdp: str, rtsp_url: str
+        self,
+        stream_id: str,
+        offer_sdp: str,
+        rtsp_url: str,
+        channel_data: dict[str, Any] | None = None,
     ) -> str:
         """Send the WebRTC offer to the RTSPtoWebRTC server."""
         _LOGGER.debug("rtsp_url=%s, offer=%s", rtsp_url, offer_sdp)
         sdp64 = base64.b64encode(offer_sdp.encode("utf-8")).decode("utf-8")
+        if channel_data is None:
+            channel_data = {}
         resp = await self._request(
             "post",
             STREAM_PATH,
             data={
                 DATA_URL: rtsp_url,
                 DATA_SDP64: sdp64,
+                **channel_data,
             },
             label="stream",
         )


### PR DESCRIPTION
Add API call to support passing extra data in the stream channel.

Issue https://github.com/allenporter/stream-addons/issues/32
Issue https://github.com/deepch/RTSPtoWeb/issues/82